### PR TITLE
add OS flavor check and add change XDG_DATA_HOME path for linux

### DIFF
--- a/.config/bash/path.sh
+++ b/.config/bash/path.sh
@@ -2,9 +2,16 @@
 #   Pathing:   Adhereing as closely as possible to XDG Base Directory Spec
 #   https://specifications.freedesktop.org/basedir-spec/latest/
 # --------------------------------------------------------------------------
+OS=$(uname)
+
+if [[ "$OS" == *"Linux"* ]]; then
+    export XDG_DATA_HOME="$HOME/.local"
+else
+    export XDG_DATA_HOME="$HOME/.local/share"
+fi
+
 export XDG_CONFIG_HOME="$HOME/.config"
 export XDG_CACHE_HOME="$HOME/.cache"
-export XDG_DATA_HOME="$HOME/.local/share"
 export XDG_STATE_HOME="$HOME/.local/state"
 
 # this relative is used for both macOS and Debian based distros
@@ -31,9 +38,9 @@ if [[ $(uname) == *"Linux"* ]]; then
     # pip_packages="/home/linuxbrew/.linuxbrew/$pip_path_suffix"
 
     # pip packages with command line tools install here by default with apt installed python
-    export PATH=$PATH:$XDG_DATA_HOME/python/bin
+    export PATH=$PATH:$XDG_DATA_HOME/bin
     # apt installed location of pip installed python3.x packages
-    pip_packages="$XDG_DATA_HOME/python/$pip_path_suffix"
+    pip_packages="$XDG_DATA_HOME/$pip_path_suffix"
 fi
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ macOS PATH ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
@@ -64,9 +71,14 @@ fi
 # python default install location when you: pip$VERSION install --user package
 export PATH=$PATH:$HOME/.local/bin:/usr/local/bin
 
-# make python do it's cache in ~/.cache/python
-export PYTHONPYCACHEPREFIX=$XDG_CACHE_HOME/python
-export PYTHONUSERBASE=$XDG_DATA_HOME/python
+if [[ "$OS" == *"Linux"* ]]; then
+    export PYTHONPYCACHEPREFIX=$XDG_CACHE_HOME
+    export PYTHONUSERBASE=$XDG_DATA_HOME
+else
+    export PYTHONPYCACHEPREFIX=$XDG_CACHE_HOME/python
+    export PYTHONUSERBASE=$XDG_DATA_HOME/python
+fi
+
 # Run py cmds in this file b4 the 1st prompt is displayed in interactive mode
 export PYTHONSTARTUP=$XDG_CONFIG_HOME/python/interactive_startup.py
 
@@ -105,4 +117,4 @@ export W3M_DIR="~/.local/state/w3m"
 # add gcloud to path on macOS because they don't have a homebrew package
 export PATH=$PATH:$HOME/.local/bin/google-cloud-sdk/bin
 # updates PATH for the Google Cloud SDK.
-if [ -f '/Users/jesse/.local/bin/google-cloud-sdk/path.bash.inc' ]; then . '/Users/jesse/.local/bin/google-cloud-sdk/path.bash.inc'; fi
+if [ -f "/Users/$USER/.local/bin/google-cloud-sdk/path.bash.inc" ]; then . "/Users/$USER/.local/bin/google-cloud-sdk/path.bash.inc"; fi


### PR DESCRIPTION
Proposed resolution for issue #26

Adds an OS flavor check and changes the XDG_DATA_HOME value for Linux.
Tested on Ubuntu22.04 and Debian12 latest daily.

Before changes:
```bash
testadmin@test:~$ echo $pip_packages
/home/testadmin/.local/share/python/lib/python3.11/site-packages

testadmin@test:~$ ls $pip_packages
lsd: /home/testadmin/.local/share/python/lib/python3.11/site-packages: No such file or directory (os error 2).

testadmin@test:~$ onboardme --help
Traceback (most recent call last):
  File "/home/testadmin/.local/bin/onboardme", line 5, in <module>
    from onboardme import main
ModuleNotFoundError: No module named 'onboardme'
testadmin@test:~$
```

after changes and login/logout
<img width="1680" alt="Screenshot 2023-04-18 at 11 21 08" src="https://user-images.githubusercontent.com/84841307/232734066-abe06bc0-de71-4745-9d4e-41c4c661a61f.png">
:

