### PR TITLE
Remove flatpak wezterm alias

### DIFF
--- a/.config/bash/alias.sh
+++ b/.config/bash/alias.sh
@@ -8,7 +8,7 @@ if [[ $(uname) == *"Darwin"* ]]; then
     alias sed='gsed'
 else
     # wezterm requires this if it's installed via flatpak
-    alias wezterm='flatpak run org.wezfurlong.wezterm'
+    # alias wezterm='flatpak run org.wezfurlong.wezterm'
     # freetube only seems to work through flatpak on debian
     alias freetube="flatpak run io.freetubeapp.FreeTube"
     # lutris works better through flatpak


### PR DESCRIPTION
Commented out the flatpak wezterm invocation since we install it through linuxbrew now.