### PR TITLE
fastfetch: Update config schema for display sub-elements

### DIFF
--- a/.config/fastfetch/config.jsonc
+++ b/.config/fastfetch/config.jsonc
@@ -13,7 +13,9 @@
                     "right": 1}
     },
     "display": {
-        "percentType": 9, // colored percent number
+        "percent": {
+            "Type": 9
+            }, // colored percent number
         "color": {
             "keys": "magenta",
             "title": "bright_blue"


### PR DESCRIPTION
fixes error: "JsonConfig Error: Property `display.percentX` has been changed to `display.percent.x`"