### PR TITLE
feat - add markdown live preview addon for neovim

### DIFF
--- a/.config/nvim/lua/user/lazy.lua
+++ b/.config/nvim/lua/user/lazy.lua
@@ -427,6 +427,7 @@ local plugins = {
         'nvim-tree/nvim-web-devicons',
         lazy = true
     },
+    -- preview markdown in a web browser
     {
         "iamcco/markdown-preview.nvim",
         cmd = { "MarkdownPreviewToggle", "MarkdownPreview", "MarkdownPreviewStop" },

--- a/.config/nvim/lua/user/lazy.lua
+++ b/.config/nvim/lua/user/lazy.lua
@@ -427,6 +427,22 @@ local plugins = {
         'nvim-tree/nvim-web-devicons',
         lazy = true
     },
+    {
+        "iamcco/markdown-preview.nvim",
+        cmd = { "MarkdownPreviewToggle", "MarkdownPreview", "MarkdownPreviewStop" },
+        ft = { "markdown" },
+        build = function() vim.fn["mkdp#util#install"]() end,
+    },
+    {
+      "iamcco/markdown-preview.nvim",
+      cmd = { "MarkdownPreviewToggle", "MarkdownPreview", "MarkdownPreviewStop" },
+      build = "cd app && yarn install",
+      init = function()
+        vim.g.mkdp_filetypes = { "markdown" }
+      end,
+      ft = { "markdown" },
+    }
+
 }
 
 require("lazy").setup(plugins)


### PR DESCRIPTION
This PR add the MarkdownPreview plugin for neovim
- https://github.com/iamcco/markdown-preview.nvim

It will open a tab in your local browser (doesnt work over ssh sadly) with a rendered version of your document. Has hot-reload and synced scrolling.

